### PR TITLE
Fix in Python3: convert bytes to str.

### DIFF
--- a/word2vec/scripts_interface.py
+++ b/word2vec/scripts_interface.py
@@ -70,6 +70,8 @@ def word2vec(train, output, size=100, window=5, sample='1e-3', hs=0,
                             stderr=subprocess.PIPE)
     if verbose:
         for line in proc.stdout:
+            if isinstance(line, bytes):
+                line = line.decode('utf-8')
             sys.stdout.write(line)
             if 'ERROR:' in line:
                 raise Exception(line)


### PR DESCRIPTION
.../py34/src/word2vec/word2vec/scripts_interface.py in word2vec(train, output, size, window, sample, hs, negative, threads, iter_, min_count, alpha, debug, binary, cbow, save_vocab, read_vocab, verbose)
     71     if verbose:
     72         for line in proc.stdout:
---> 73             sys.stdout.write(line)
     74             if 'ERROR:' in line:
     75                 raise Exception(line)

TypeError: must be str, not bytes
